### PR TITLE
Show the nearby chip for images and files too.

### DIFF
--- a/core/java/com/android/internal/app/ChooserActivity.java
+++ b/core/java/com/android/internal/app/ChooserActivity.java
@@ -930,7 +930,7 @@ public class ChooserActivity extends ResolverActivity {
         final ComponentName cn = getNearbySharingComponent();
         if (cn == null) return null;
 
-        final Intent resolveIntent = new Intent();
+        final Intent resolveIntent = new Intent(originalIntent);
         resolveIntent.setComponent(cn);
         final ResolveInfo ri = getPackageManager().resolveActivity(
                 resolveIntent, PackageManager.GET_META_DATA);
@@ -1097,6 +1097,13 @@ public class ChooserActivity extends ResolverActivity {
             ViewGroup parent) {
         ViewGroup contentPreviewLayout = (ViewGroup) layoutInflater.inflate(
                 R.layout.chooser_grid_preview_image, parent, false);
+
+
+        final ViewGroup actionRow =
+               (ViewGroup) contentPreviewLayout.findViewById(R.id.chooser_action_row);
+        //TODO: addActionButton(actionRow, createCopyButton());
+        addActionButton(actionRow, createNearbyButton(targetIntent));
+
         mPreviewCoord = new ContentPreviewCoordinator(contentPreviewLayout, true);
 
         String action = targetIntent.getAction();
@@ -1207,10 +1214,10 @@ public class ChooserActivity extends ResolverActivity {
         ViewGroup contentPreviewLayout = (ViewGroup) layoutInflater.inflate(
                 R.layout.chooser_grid_preview_file, parent, false);
 
-        // TODO(b/120417119): Disable file copy until after moving to sysui,
-        // due to permissions issues
-        //((ViewGroup) contentPreviewLayout.findViewById(R.id.chooser_action_row))
-        //        .addView(createCopyButton());
+        final ViewGroup actionRow =
+                (ViewGroup) contentPreviewLayout.findViewById(R.id.chooser_action_row);
+        //TODO(b/120417119): addActionButton(actionRow, createCopyButton());
+        addActionButton(actionRow, createNearbyButton(targetIntent));
 
         String action = targetIntent.getAction();
         if (Intent.ACTION_SEND.equals(action)) {


### PR DESCRIPTION
This revealed that we weren't initializing the nearby intent
from the original intent, so that's fixed too. This should
ensure that flags and extras from the original intent make
their way to the available and installed nearby component.

Change-Id: I0cac4b1ac63d95b0f0d2ef8d2e614674253c7cb4
Test: Share (an image and a non-image) from DocumentsUI
Fixes: 155487375
Fixes: 155676993
Merged-In: If0c0b754a066b0ec439a866de3eae84caca7b793